### PR TITLE
实现歌词获取功能并同步到系统媒体控制中心、修复多艺术家时只显示一个

### DIFF
--- a/entry/src/main/ets/entryability/EntryAbility.ets
+++ b/entry/src/main/ets/entryability/EntryAbility.ets
@@ -6,6 +6,7 @@ import { deviceInfo } from '@kit.BasicServicesKit';
 import { webview } from '@kit.ArkWeb';
 import { emitter } from '@kit.BasicServicesKit';
 import { AVSessionService } from '../service/AVSessionService';
+import { PreferencesUtil } from '../utiles/PreferencesHelper';
 
 const DOMAIN = 0x0000;
 
@@ -23,6 +24,14 @@ export default class EntryAbility extends UIAbility {
     webview.WebviewController.enableBackForwardCache(features);
     webview.WebviewController.initializeWebEngine();
     AppStorage.setOrCreate("abilityWant", want);
+
+
+    // 初始化本地存储
+    PreferencesUtil.init(this.context).then(() => {
+      hilog.info(DOMAIN, 'testTag', '%{public}s', 'Preferences initialized successfully');
+    }).catch((err: BusinessError) => {
+      hilog.error(DOMAIN, 'testTag', 'Failed to initialize Preferences: %{public}s', JSON.stringify(err));
+    });
 
     // 初始化 AVSession
     this.avSessionService.initialize(this.context).then(() => {

--- a/entry/src/main/ets/service/AVSessionService.ets
+++ b/entry/src/main/ets/service/AVSessionService.ets
@@ -52,6 +52,11 @@ export class AVSessionService {
     return AVSessionService.instance;
   }
 
+  // 获取 AVSession 实例
+  public getSession(): AVSessionManager.AVSession | null {
+    return this.session;
+  }
+
   // 初始化 AVSession
   public async initialize(context: common.UIAbilityContext): Promise<void> {
     this.context = context;

--- a/entry/src/main/ets/service/LyricService.ets
+++ b/entry/src/main/ets/service/LyricService.ets
@@ -1,0 +1,299 @@
+/**
+ * 网易云音乐歌词服务
+ * 负责获取原始 LRC 歌词数据，由系统 AVSession 处理解析和显示
+ */
+import { http } from '@kit.NetworkKit';
+import { webview } from '@kit.ArkWeb';
+import { NeteaseEncrypt, EncryptedParams } from '../utils/NeteaseEncrypt';
+
+// 网易云音乐 API 基础 URL
+const NETEASE_BASE_URL = 'https://music.163.com';
+const LYRIC_API_PATH = '/weapi/song/lyric/v1';
+
+/**
+ * 歌词数据
+ */
+export interface LyricData {
+  songId: number;           // 歌曲 ID
+  hasLyric: boolean;        // 是否有歌词
+  rawLyric: string;         // 原始歌词文本（LRC 格式）
+}
+
+/**
+ * API 响应中的歌词对象
+ */
+interface LyricObject {
+  lyric?: string;
+}
+
+/**
+ * 网易云音乐歌词 API 响应
+ */
+interface LyricApiResponse {
+  code: number;
+  lrc?: LyricObject;
+  tlyric?: LyricObject;
+  romalrc?: LyricObject;
+}
+
+/**
+ * 歌词请求参数
+ */
+interface LyricRequestData {
+  id: number;
+  cp: boolean;
+  tv: number;
+  lv: number;
+  rv: number;
+  kv: number;
+  yv: number;
+  ytv: number;
+  yrv: number;
+}
+
+/**
+ * 歌词变化回调
+ */
+export type LyricChangeCallback = (lyricData: LyricData) => void;
+
+/**
+ * 歌词服务类
+ */
+export class LyricService {
+  private static instance: LyricService | null = null;
+  private lyricCache: Map<number, LyricData> = new Map();
+  private currentSongId: number = 0;
+  private currentLyric: LyricData | null = null;
+  private callbacks: LyricChangeCallback[] = [];
+
+  private constructor() {}
+
+  /**
+   * 获取单例实例
+   */
+  public static getInstance(): LyricService {
+    if (!LyricService.instance) {
+      LyricService.instance = new LyricService();
+    }
+    return LyricService.instance;
+  }
+
+  /**
+   * 注册歌词变化回调
+   */
+  public onLyricChange(callback: LyricChangeCallback): void {
+    this.callbacks.push(callback);
+  }
+
+  /**
+   * 移除歌词变化回调
+   */
+  public offLyricChange(callback: LyricChangeCallback): void {
+    const index = this.callbacks.indexOf(callback);
+    if (index > -1) {
+      this.callbacks.splice(index, 1);
+    }
+  }
+
+  /**
+   * 通知所有回调
+   */
+  private notifyCallbacks(lyricData: LyricData): void {
+    for (const callback of this.callbacks) {
+      try {
+        callback(lyricData);
+      } catch (error) {
+        console.error('[LyricService] Callback error:', error);
+      }
+    }
+  }
+
+  /**
+   * 获取当前歌词数据
+   */
+  public getCurrentLyric(): LyricData | null {
+    return this.currentLyric;
+  }
+
+  /**
+   * 获取当前歌曲 ID
+   */
+  public getCurrentSongId(): number {
+    return this.currentSongId;
+  }
+
+  /**
+   * 从 Cookie 字符串中提取 csrf_token
+   */
+  private extractCsrfToken(cookieStr: string): string {
+    if (!cookieStr) return '';
+    const cookies = cookieStr.split(';');
+    for (const cookie of cookies) {
+      const parts = cookie.trim().split('=');
+      const name = parts[0];
+      const value = parts.length > 1 ? parts[1] : '';
+      if (name === '__csrf') {
+        return value || '';
+      }
+    }
+    return '';
+  }
+
+  /**
+   * 获取 Cookie（从 WebCookieManager）
+   */
+  private async getCookies(): Promise<string> {
+    try {
+      const cookies = await webview.WebCookieManager.fetchCookie(NETEASE_BASE_URL);
+      return cookies || '';
+    } catch (error) {
+      console.error('[LyricService] Failed to get cookies:', error);
+      return '';
+    }
+  }
+
+  /**
+   * 过滤歌词，只保留标准 LRC 格式的行
+   * 移除 JSON 格式的元数据行（如作词、作曲信息）
+   */
+  private filterLyric(rawLyric: string): string {
+    if (!rawLyric) return '';
+
+    const lines = rawLyric.split('\n');
+    const filteredLines: string[] = [];
+    // 标准 LRC 时间标签格式: [mm:ss.xx] 或 [mm:ss.xxx]
+    const lrcTimePattern = /^\[(\d{2}):(\d{2})\.(\d{2,3})\]/;
+
+    for (const line of lines) {
+      const trimmedLine = line.trim();
+      // 跳过空行
+      if (!trimmedLine) continue;
+      // 跳过 JSON 格式的行（以 { 开头）
+      if (trimmedLine.startsWith('{')) continue;
+      // 只保留标准 LRC 时间标签格式的行
+      if (lrcTimePattern.test(trimmedLine)) {
+        filteredLines.push(line);
+      }
+    }
+
+    return filteredLines.join('\n');
+  }
+
+  /**
+   * 获取歌词
+   * @param songId 歌曲 ID
+   * @param forceRefresh 是否强制刷新（忽略缓存）
+   */
+  public async fetchLyric(songId: number, forceRefresh: boolean = false): Promise<LyricData> {
+    if (songId <= 0) {
+      throw new Error('Invalid song ID');
+    }
+
+    // 检查缓存
+    if (!forceRefresh && this.lyricCache.has(songId)) {
+      const cached = this.lyricCache.get(songId)!;
+      this.currentSongId = songId;
+      this.currentLyric = cached;
+      this.notifyCallbacks(cached);
+      console.info(`[LyricService] Using cached lyric for song ${songId}`);
+      return cached;
+    }
+
+    console.info(`[LyricService] Fetching lyric for song ${songId}`);
+
+    try {
+      // 获取 Cookie 和 csrf_token
+      const cookies = await this.getCookies();
+      const csrfToken = this.extractCsrfToken(cookies);
+
+      // 构造请求参数
+      const requestData: LyricRequestData = {
+        id: songId,
+        cp: false,
+        tv: 0,
+        lv: 0,
+        rv: 0,
+        kv: 0,
+        yv: 0,
+        ytv: 0,
+        yrv: 0
+      };
+
+      // 加密参数
+      const encryptedParams: EncryptedParams = await NeteaseEncrypt.encrypt(requestData);
+
+      // 构造请求 URL
+      const url = `${NETEASE_BASE_URL}${LYRIC_API_PATH}?csrf_token=${csrfToken}`;
+
+      // 发送请求
+      const httpRequest = http.createHttp();
+      const response = await httpRequest.request(url, {
+        method: http.RequestMethod.POST,
+        header: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Cookie': cookies,
+          'Referer': 'https://music.163.com/',
+          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
+        },
+        extraData: `params=${encodeURIComponent(encryptedParams.params)}&encSecKey=${encodeURIComponent(encryptedParams.encSecKey)}`
+      });
+
+      httpRequest.destroy();
+
+      if (response.responseCode !== 200) {
+        throw new Error(`HTTP error: ${response.responseCode}`);
+      }
+
+      // 解析响应
+      const responseData = JSON.parse(response.result as string) as LyricApiResponse;
+
+      if (responseData.code !== 200) {
+        throw new Error(`API error: ${responseData.code}`);
+      }
+
+      // 获取原始歌词文本并过滤非标准内容
+      const rawLyricOriginal = responseData.lrc?.lyric || '';
+      const rawLyric = this.filterLyric(rawLyricOriginal);
+
+      const lyricData: LyricData = {
+        songId: songId,
+        hasLyric: rawLyric.length > 0,
+        rawLyric: rawLyric
+      };
+
+      // 缓存结果
+      this.lyricCache.set(songId, lyricData);
+      this.currentSongId = songId;
+      this.currentLyric = lyricData;
+
+      // 通知回调
+      this.notifyCallbacks(lyricData);
+
+      console.info(`[LyricService] Fetched lyric for song ${songId}, original: ${rawLyricOriginal.length}, filtered: ${rawLyric.length}`);
+      return lyricData;
+
+    } catch (error) {
+      console.error(`[LyricService] Failed to fetch lyric for song ${songId}:`, error);
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw new Error(`Failed to fetch lyric: ${String(error)}`);
+    }
+  }
+
+  /**
+   * 清除缓存
+   */
+  public clearCache(): void {
+    this.lyricCache.clear();
+    console.info('[LyricService] Cache cleared');
+  }
+
+  /**
+   * 清除指定歌曲的缓存
+   */
+  public clearCacheForSong(songId: number): void {
+    this.lyricCache.delete(songId);
+    console.info(`[LyricService] Cache cleared for song ${songId}`);
+  }
+}

--- a/entry/src/main/ets/service/WebMusicBridge.ets
+++ b/entry/src/main/ets/service/WebMusicBridge.ets
@@ -1,6 +1,11 @@
 import { webview } from '@kit.ArkWeb';
 import { avSession as AVSessionManager } from '@kit.AVSessionKit';
 import { AVSessionService, MediaInfo, PlaybackInfo, AVSessionCallback } from './AVSessionService';
+import { PreferencesUtil } from '../utiles/PreferencesHelper';
+import { LyricService } from './LyricService';
+
+// 持久化存储的 key
+const LAST_SONG_ID_KEY = 'lastSongId';
 
 // 从网页端接收的媒体信息接口
 interface WebMediaInfo {
@@ -11,6 +16,7 @@ interface WebMediaInfo {
   duration?: number;
   picUrl?: string;
   isFavorite?: boolean;
+  songId?: number; // 网易云音乐歌曲 ID（通过网络请求拦截获取）
 }
 
 // 从网页端接收的播放状态接口
@@ -37,13 +43,50 @@ export interface AVSessionBridgeObject {
 export class WebMusicBridge {
   private controller: webview.WebviewController;
   private avSessionService: AVSessionService;
+  private lyricService: LyricService;
   private isInjected: boolean = false;
   private currentMediaId: string = '';
+  private currentSongId: number = 0; // 网易云音乐歌曲 ID（通过网络请求拦截获取）
 
   constructor(controller: webview.WebviewController) {
     this.controller = controller;
     this.avSessionService = AVSessionService.getInstance();
+    this.lyricService = LyricService.getInstance();
     this.setupAVSessionCallbacks();
+    this.loadLastSongId();
+  }
+
+  // 从持久化存储加载上次保存的歌曲 ID
+  private loadLastSongId(): void {
+    try {
+      if (PreferencesUtil.isInitialized()) {
+        const lastSongId = PreferencesUtil.get<number>(LAST_SONG_ID_KEY, 0);
+        if (lastSongId && lastSongId > 0) {
+          this.currentSongId = lastSongId;
+          console.info(`[WebMusicBridge] Loaded last song ID from storage: ${lastSongId}`);
+        }
+      }
+    } catch (err) {
+      console.error(`[WebMusicBridge] Failed to load last song ID: ${err}`);
+    }
+  }
+
+  // 保存歌曲 ID 到持久化存储
+  private saveSongId(songId: number): void {
+    if (songId <= 0) return;
+    try {
+      if (PreferencesUtil.isInitialized()) {
+        PreferencesUtil.put(LAST_SONG_ID_KEY, songId);
+        console.info(`[WebMusicBridge] Saved song ID to storage: ${songId}`);
+      }
+    } catch (err) {
+      console.error(`[WebMusicBridge] Failed to save song ID: ${err}`);
+    }
+  }
+
+  // 获取当前歌曲 ID（优先使用拦截到的 ID，否则使用持久化存储的 ID）
+  public getCurrentSongId(): number {
+    return this.currentSongId;
   }
 
   // 设置 AVSession 回调，将播控命令转发到网页
@@ -301,12 +344,19 @@ export class WebMusicBridge {
   public injectMusicMonitor(): void {
     if (this.isInjected) return;
 
+    // 获取上次保存的歌曲 ID，用于初始化
+    const lastSongId = this.currentSongId;
+
     const jsCode = `
       (function() {
         if (window.__avSessionInjected) return;
         window.__avSessionInjected = true;
 
         console.log('[AVSession] Injecting music monitor for NetEase Cloud Music...');
+
+        // 从 Native 层传入的上次保存的歌曲 ID
+        const LAST_SAVED_SONG_ID = ${lastSongId};
+        console.log('[AVSession] Last saved song ID from storage:', LAST_SAVED_SONG_ID);
 
         // 状态缓存
         const state = {
@@ -315,6 +365,7 @@ export class WebMusicBridge {
           isFavorite: false,
           loopMode: 'list',
           songId: '',
+          numericSongId: LAST_SAVED_SONG_ID, // 使用上次保存的歌曲 ID 作为初始值
           songName: '',
           artist: '',
           coverUrl: '',
@@ -325,8 +376,144 @@ export class WebMusicBridge {
           // Howler 追踪
           activeHowlId: null,
           howlInstances: new Map(), // id -> { howl, createdAt, lastSeek }
-          lastHowlCheck: 0
+          lastHowlCheck: 0,
+          // 网络拦截获取的歌曲 ID
+          interceptedSongId: LAST_SAVED_SONG_ID, // 使用上次保存的歌曲 ID 作为初始值
+          lastInterceptedSongId: 0
         };
+
+        // ========== 网络请求拦截 ==========
+        // 通过拦截 weapi/song/enhance/player/url/v1 接口获取真实歌曲 ID
+        const TARGET_PATH = 'weapi/song/enhance/player/url/v1';
+
+        // 拦截 XMLHttpRequest
+        const originalXhrOpen = XMLHttpRequest.prototype.open;
+        const originalXhrSend = XMLHttpRequest.prototype.send;
+
+        XMLHttpRequest.prototype.open = function(method, url, ...args) {
+          this._avSessionUrl = url;
+          return originalXhrOpen.apply(this, [method, url, ...args]);
+        };
+
+        XMLHttpRequest.prototype.send = function(body) {
+          this.addEventListener('load', function() {
+            if (this._avSessionUrl && this._avSessionUrl.indexOf(TARGET_PATH) > -1) {
+              try {
+                const res = JSON.parse(this.responseText);
+                if (res.data && res.data[0] && res.data[0].id) {
+                  const songId = res.data[0].id;
+                  console.log('[AVSession] XHR Intercepted song ID:', songId);
+                  state.interceptedSongId = songId;
+                  // 通知歌曲 ID 变化
+                  notifySongIdChange(songId);
+                }
+              } catch (e) {
+                console.error('[AVSession] XHR parse error:', e);
+              }
+            }
+          });
+          return originalXhrSend.apply(this, [body]);
+        };
+
+        // 拦截 Fetch
+        const originalFetch = window.fetch;
+        window.fetch = async function(...args) {
+          const response = await originalFetch(...args);
+
+          let url = '';
+          if (typeof args[0] === 'string') url = args[0];
+          else if (args[0] instanceof Request) url = args[0].url;
+
+          if (url && url.indexOf(TARGET_PATH) > -1) {
+            const clone = response.clone();
+            clone.json().then(data => {
+              if (data.data && data.data[0] && data.data[0].id) {
+                const songId = data.data[0].id;
+                console.log('[AVSession] Fetch Intercepted song ID:', songId);
+                state.interceptedSongId = songId;
+                // 通知歌曲 ID 变化
+                notifySongIdChange(songId);
+              }
+            }).catch(err => console.error('[AVSession] Fetch parse error:', err));
+          }
+          return response;
+        };
+
+        console.log('[AVSession] Network interceptor installed for:', TARGET_PATH);
+
+        // 通知歌曲 ID 变化（当拦截到新的歌曲 ID 时调用）
+        function notifySongIdChange(songId) {
+          if (!songId || songId <= 0) {
+            console.warn('[AVSession] Invalid song ID received:', songId);
+            return;
+          }
+
+          if (songId === state.lastInterceptedSongId) {
+            console.log('[AVSession] Same song ID, skipping:', songId);
+            return;
+          }
+
+          console.log('[AVSession] New song ID detected:', songId, '(previous:', state.lastInterceptedSongId, ')');
+          state.lastInterceptedSongId = songId;
+          state.numericSongId = songId;
+
+          // 延迟获取歌曲信息，确保 UI 和 Howler 已更新
+          let retryCount = 0;
+          const maxRetries = 5;
+          const retryInterval = 200;
+
+          function tryNotify() {
+            retryCount++;
+            const { songName, artist, coverUrl } = getSongInfo();
+            const { duration } = getProgressInfo();
+
+            console.log('[AVSession] Try notify #' + retryCount + ':', songName, '-', artist, 'duration:', duration, 'songId:', songId);
+
+            // 验证数据有效性
+            if (!songName) {
+              if (retryCount < maxRetries) {
+                console.log('[AVSession] Song name not ready, retrying...');
+                setTimeout(tryNotify, retryInterval);
+                return;
+              }
+              console.warn('[AVSession] Failed to get song name after', maxRetries, 'retries');
+              return;
+            }
+
+            // 检查 duration 是否有效（大于 0 且合理）
+            if (duration <= 0 || duration > 3600) {
+              if (retryCount < maxRetries) {
+                console.log('[AVSession] Duration not ready:', duration, ', retrying...');
+                setTimeout(tryNotify, retryInterval);
+                return;
+              }
+              console.warn('[AVSession] Using potentially invalid duration:', duration);
+            }
+
+            const info = {
+              id: songName + '-' + artist,
+              name: songName,
+              artist: artist,
+              picUrl: coverUrl,
+              duration: duration,
+              isFavorite: state.isFavorite,
+              songId: songId
+            };
+
+            // 更新 state 中的歌曲信息
+            state.songId = info.id;
+            state.songName = songName;
+            state.artist = artist;
+            state.coverUrl = coverUrl;
+            state.duration = duration;
+
+            console.log('[AVSession] Notifying song change - ID:', songId, 'Name:', songName, 'Duration:', duration);
+            notifySongChange(info);
+          }
+
+          // 首次延迟 300ms 后开始尝试
+          setTimeout(tryNotify, 300);
+        }
 
         // ========== Howler.js 追踪 ==========
 
@@ -507,8 +694,18 @@ export class WebMusicBridge {
                 const authorEl = titleDiv.querySelector('.author') ||
                                 titleDiv.querySelector('[class*="author"]');
                 if (authorEl) {
-                  const authorLink = authorEl.querySelector('a');
-                  artist = authorLink?.textContent?.trim() || authorEl.textContent?.trim() || '';
+                  // 获取所有歌手链接，支持多歌手情况
+                  const authorLinks = authorEl.querySelectorAll('a');
+                  if (authorLinks.length > 0) {
+                    const artists = [];
+                    for (let i = 0; i < authorLinks.length; i++) {
+                      const name = authorLinks[i].textContent?.trim();
+                      if (name) artists.push(name);
+                    }
+                    artist = artists.join(' / ');
+                  } else {
+                    artist = authorEl.textContent?.trim() || '';
+                  }
                 }
               }
             }
@@ -523,12 +720,24 @@ export class WebMusicBridge {
               }
             }
             if (!artist) {
-              const artistSelectors = ['.author a', '[class*="artist"] a', '[class*="singer"] a'];
-              for (const sel of artistSelectors) {
-                const el = document.querySelector(sel);
-                if (el) {
-                  artist = el.textContent?.trim() || '';
-                  if (artist) break;
+              // 尝试获取所有歌手，支持多歌手情况
+              const artistContainers = ['.author', '[class*="artist"]', '[class*="singer"]'];
+              for (const containerSel of artistContainers) {
+                const container = document.querySelector(containerSel);
+                if (container) {
+                  const links = container.querySelectorAll('a');
+                  if (links.length > 0) {
+                    const artists = [];
+                    for (let i = 0; i < links.length; i++) {
+                      const name = links[i].textContent?.trim();
+                      if (name) artists.push(name);
+                    }
+                    artist = artists.join(' / ');
+                    if (artist) break;
+                  } else {
+                    artist = container.textContent?.trim() || '';
+                    if (artist) break;
+                  }
                 }
               }
             }
@@ -715,6 +924,8 @@ export class WebMusicBridge {
         }
 
         // ========== 主监控函数 ==========
+        // 注意：歌曲信息的上报完全由网络拦截器的 notifySongIdChange 负责
+        // monitor() 只负责播放状态、喜欢状态、循环模式的更新
 
         function monitor(forceNotify = false) {
           const isPlaying = checkPlayState();
@@ -722,7 +933,6 @@ export class WebMusicBridge {
           const loopMode = checkLoopMode();
           const { currentTime, duration } = getProgressInfo();
           const { songName, artist, coverUrl } = getSongInfo();
-          const songId = songName + '-' + artist;
 
           let stateChanged = false;
 
@@ -739,25 +949,34 @@ export class WebMusicBridge {
             stateChanged = true;
           }
 
-          // 状态变化或强制通知时上报
+          // 更新 duration（供 notifySongIdChange 使用）
+          if (duration > 0) {
+            state.duration = duration;
+          }
+
+          // 状态变化或强制通知时上报播放状态
           if (stateChanged || forceNotify) {
             notifyPlayStateChange(state.isPlaying, currentTime, duration, state.isFavorite, state.loopMode);
           }
 
-          // 歌曲变化时上报
-          if (songName && (songId !== state.songId || forceNotify)) {
+          // 强制通知时（初始化），上报当前歌曲信息
+          // 这是唯一在 monitor() 中上报歌曲信息的情况
+          if (forceNotify && songName) {
+            const songId = songName + '-' + artist;
+            const numericId = state.numericSongId || state.interceptedSongId || 0;
             state.songId = songId;
             state.songName = songName;
             state.artist = artist;
             state.coverUrl = coverUrl;
-            state.duration = duration;
+            console.log('[AVSession] Force notify (init) song:', songName, '-', artist, 'numericId:', numericId, 'duration:', duration);
             notifySongChange({
               id: songId,
               name: songName,
               artist: artist,
               picUrl: coverUrl,
               duration: duration,
-              isFavorite: state.isFavorite
+              isFavorite: state.isFavorite,
+              songId: numericId
             });
           }
 
@@ -947,6 +1166,16 @@ export class WebMusicBridge {
     if (mediaId === this.currentMediaId) return;
     this.currentMediaId = mediaId;
 
+    // 记录网易云音乐歌曲 ID（通过网络请求拦截获取）并保存到持久化存储
+    if (info.songId && info.songId > 0) {
+      this.currentSongId = info.songId;
+      this.saveSongId(info.songId); // 保存到持久化存储
+      console.info(`[WebMusicBridge] Intercepted song ID: ${info.songId}`);
+
+      // 自动获取歌词
+      this.fetchLyricForSong(info.songId);
+    }
+
     const mediaInfo: MediaInfo = {
       assetId: mediaId,
       title: info.name || '未知歌曲',
@@ -967,7 +1196,55 @@ export class WebMusicBridge {
       await this.avSessionService.setPlaybackState(playbackInfo);
     }
 
-    console.info(`[WebMusicBridge] Song: ${info.name} - ${info.artist}, duration: ${info.duration}s`);
+    console.info(`[WebMusicBridge] Song: ${info.name} - ${info.artist}, duration: ${info.duration}s, songId: ${this.currentSongId}`);
+  }
+
+  /**
+   * 获取指定歌曲的歌词并更新到 AVSession
+   * @param songId 歌曲 ID
+   */
+  private async fetchLyricForSong(songId: number): Promise<void> {
+    try {
+      console.info(`[WebMusicBridge] Fetching lyric for song ${songId}`);
+      const lyricData = await this.lyricService.fetchLyric(songId);
+
+      console.info(`[WebMusicBridge] Fetched lyric: ${lyricData.rawLyric}`)
+
+      // 将歌词更新到 AVSession metadata
+      if (lyricData.hasLyric && lyricData.rawLyric) {
+        await this.updateLyricToSession(lyricData.rawLyric);
+      }
+    } catch (error) {
+      console.error(`[WebMusicBridge] Failed to fetch lyric for song ${songId}:`, error);
+    }
+  }
+
+  /**
+   * 更新歌词到 AVSession metadata
+   * @param lyric 原始歌词文本（LRC 格式）
+   */
+  private async updateLyricToSession(lyric: string): Promise<void> {
+    try {
+      // 直接调用 session 的 setAVMetadata 只更新歌词字段
+      const session = this.avSessionService.getSession();
+      if (session) {
+        const metadata: AVSessionManager.AVMetadata = {
+          assetId: this.currentMediaId || '0',
+          lyric: lyric
+        };
+        await session.setAVMetadata(metadata);
+        console.info(`[WebMusicBridge] Lyric updated to AVSession, length: ${lyric.length}`);
+      }
+    } catch (error) {
+      console.error('[WebMusicBridge] Failed to update lyric to session:', error);
+    }
+  }
+
+  /**
+   * 获取歌词服务实例
+   */
+  public getLyricService(): LyricService {
+    return this.lyricService;
   }
 
   // 获取桥接对象，用于注册到 Web 组件

--- a/entry/src/main/ets/utiles/PreferencesHelper.ets
+++ b/entry/src/main/ets/utiles/PreferencesHelper.ets
@@ -1,0 +1,157 @@
+import dataPreferences from '@ohos.data.preferences'
+import { common } from '@kit.AbilityKit'
+import { BusinessError } from '@kit.BasicServicesKit'
+
+
+const TAG = "PreferencesUtil"
+const P_NAME = 'application_settings'
+type ValueType = number | string | boolean | Array<number> | Array<string> | Array<boolean> | Uint8Array | object
+  | bigint ;
+
+export class PreferencesUtil {
+  private static preferences: dataPreferences.Preferences
+  private static preferencesAsync: Promise<dataPreferences.Preferences>
+
+  private constructor() {
+  }
+
+  public static isInitialized() {
+    if (PreferencesUtil.preferences) {
+      return true;
+    }
+    return false;
+  }
+
+  public static async init(context: common.UIAbilityContext, name: string = P_NAME) {
+    if (PreferencesUtil.preferences) return
+    PreferencesUtil.preferences = dataPreferences.getPreferencesSync(context, { name })
+    PreferencesUtil.preferencesAsync = dataPreferences.getPreferences(context, name).then(r => {
+      return r
+    })
+  }
+
+  private static async getPreferencesAsync(): Promise<dataPreferences.Preferences> {
+    if (!(await PreferencesUtil.preferencesAsync)) {
+      throw new Error('调用init()方法完成初始化')
+    }
+    return PreferencesUtil.preferencesAsync
+  }
+
+
+  private static getPreferences(): dataPreferences.Preferences {
+    if (!PreferencesUtil.preferences) {
+      throw new Error('调用init()方法完成初始化')
+    }
+    return PreferencesUtil.preferences
+  }
+
+
+  static async getAsync<T extends ValueType>(key: string, def?: ValueType): Promise<T> {
+    const p = await PreferencesUtil.getPreferencesAsync()
+    return new Promise<T>((resolve, reject) => {
+      p.get(key, def, (err: BusinessError, data: dataPreferences.ValueType) => {
+        if (err) {
+          console.error(TAG, err.message)
+          reject(def)
+        }
+        if (data) {
+          resolve(data as T)
+        }
+      })
+    })
+  }
+
+
+  static get<T extends ValueType>(key: string, def?: ValueType): T {
+    try {
+      return PreferencesUtil.getPreferences().getSync(key, def) as T
+    } catch (e) {
+      console.error(TAG, e)
+    }
+    return def as T
+  }
+
+
+  static async getAllAsync(): Promise<Object> {
+    let preferences = await PreferencesUtil.getPreferencesAsync()
+    return preferences.getAll()
+  }
+
+  static getAll(): Object | null {
+    try {
+      return PreferencesUtil.getPreferences().getAllSync()
+    } catch (e) {
+      console.error(TAG, e)
+    }
+    return null
+  }
+
+  static async putAsync(key: string, value: ValueType): Promise<void> {
+    const r = await PreferencesUtil.getPreferencesAsync().then(async (p) => {
+      await p.put(key, value)
+      await p.flush();
+    }).catch((err: Error) => {
+      console.error(TAG, err.message)
+    })
+    return r
+  }
+
+
+  static put(key: string, value: ValueType): void {
+    try {
+      PreferencesUtil.getPreferences().putSync(key, value)
+      PreferencesUtil.getPreferences().flush()
+    } catch (e) {
+      console.error(TAG, e)
+    }
+
+  }
+
+  static hasKey(key: string): boolean {
+    let has: boolean = false
+    try {
+      has = PreferencesUtil.getPreferences().hasSync(key)
+    } catch (e) {
+      console.error(TAG, e)
+    }
+    return has
+  }
+
+  static async deleteAsync(key: string): Promise<void> {
+    return (await PreferencesUtil.getPreferencesAsync()).delete(key)
+      .catch((err: Error) => {
+        console.error(TAG, err.message)
+      })
+      .finally(async () => {
+        (await PreferencesUtil.getPreferencesAsync()).flush()
+      })
+  }
+
+  static delete(key: string): void {
+    try {
+      PreferencesUtil.getPreferences().deleteSync(key)
+      PreferencesUtil.getPreferences().flush()
+    } catch (e) {
+      console.error(TAG, e)
+    }
+  }
+
+  static async clearAsync(): Promise<void> {
+    return (await PreferencesUtil.getPreferencesAsync()).clear()
+      .catch((err: Error) => {
+        console.error(TAG, err.message)
+      })
+      .finally(async () => {
+        (await PreferencesUtil.getPreferencesAsync()).flush()
+      })
+  }
+
+  static clear(): void {
+    try {
+      PreferencesUtil.preferences.clearSync()
+      PreferencesUtil.preferences.flush()
+    } catch (e) {
+      console.error(TAG, e)
+    }
+  }
+}

--- a/entry/src/main/ets/utils/NeteaseEncrypt.ets
+++ b/entry/src/main/ets/utils/NeteaseEncrypt.ets
@@ -1,0 +1,417 @@
+/**
+ * 网易云音乐 API 请求参数加密工具类
+ * 实现 weapi 接口的加密算法
+ */
+import { cryptoFramework } from '@kit.CryptoArchitectureKit';
+import { buffer } from '@kit.ArkTS';
+import { util } from '@kit.ArkTS';
+
+// 网易云音乐加密常量
+const MODULUS = '00e0b509f6259df8642dbc35662901477df22677ec152b5ff68ace615bb7b725152b3ab17a876aea8a5aa76d2e417629ec4ee341f56135fccf695280104e0312ecbda92557c93870114af6c9d05c4f7f0c3685b7a46bee255932575cce10b424d813cfe4875d3e82047b97ddef52741d546b8e289dc6935b3ece0462db0a22b8e7';
+const NONCE = '0CoJUm6Qyw8W8jud';
+const PUB_KEY = '010001';
+const IV = '0102030405060708';
+
+/**
+ * 加密结果接口
+ */
+export interface EncryptedParams {
+  params: string;
+  encSecKey: string;
+}
+
+/**
+ * 网易云音乐加密工具类
+ */
+export class NeteaseEncrypt {
+  /**
+   * 生成随机字符串
+   * @param length 字符串长度
+   * @returns 随机字符串
+   */
+  private static generateRandomString(length: number): string {
+    const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+    let result = '';
+    for (let i = 0; i < length; i++) {
+      const randomIndex = Math.floor(Math.random() * chars.length);
+      result += chars.charAt(randomIndex);
+    }
+    return result;
+  }
+
+  /**
+   * AES-128-CBC 加密
+   * @param text 明文
+   * @param key 密钥（16字节）
+   * @returns Base64 编码的密文
+   */
+  private static async aesEncrypt(text: string, key: string): Promise<string> {
+    try {
+      // 将 key 和 iv 转换为 Uint8Array
+      const keyData = new Uint8Array(buffer.from(key, 'utf-8').buffer);
+      const ivData = new Uint8Array(buffer.from(IV, 'utf-8').buffer);
+      const plainData = new Uint8Array(buffer.from(text, 'utf-8').buffer);
+
+      // 创建对称密钥
+      const symKeyGenerator = cryptoFramework.createSymKeyGenerator('AES128');
+      const symKeyBlob: cryptoFramework.DataBlob = { data: keyData };
+      const symKey = await symKeyGenerator.convertKey(symKeyBlob);
+
+      // 创建 IV 参数
+      const ivParamsSpec: cryptoFramework.IvParamsSpec = {
+        algName: 'IvParamsSpec',
+        iv: { data: ivData }
+      };
+
+      // 创建 Cipher 并加密
+      const cipher = cryptoFramework.createCipher('AES128|CBC|PKCS7');
+      await cipher.init(cryptoFramework.CryptoMode.ENCRYPT_MODE, symKey, ivParamsSpec);
+      const cipherData = await cipher.doFinal({ data: plainData });
+
+      // 返回 Base64 编码的密文
+      const base64Helper = new util.Base64Helper();
+      return base64Helper.encodeToStringSync(cipherData.data);
+    } catch (error) {
+      console.error('[NeteaseEncrypt] AES encrypt error:', error);
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw new Error(`AES encrypt error: ${String(error)}`);
+    }
+  }
+
+  /**
+   * 字符串反转
+   */
+  private static reverseString(str: string): string {
+    return str.split('').reverse().join('');
+  }
+
+  /**
+   * 将十六进制字符串转换为 BigInt 数组表示
+   * 使用 16 位为一个 digit
+   */
+  private static hexToBigIntArray(hex: string): number[] {
+    const digits: number[] = [];
+    for (let i = hex.length; i > 0; i -= 4) {
+      const start = Math.max(i - 4, 0);
+      const chunk = hex.substring(start, i);
+      digits.push(parseInt(chunk, 16) || 0);
+    }
+    // 确保数组足够大
+    while (digits.length < 131) {
+      digits.push(0);
+    }
+    return digits;
+  }
+
+  /**
+   * BigInt 数组转换为十六进制字符串
+   */
+  private static bigIntArrayToHex(digits: number[]): string {
+    let result = '';
+    let started = false;
+    for (let i = digits.length - 1; i >= 0; i--) {
+      if (digits[i] !== 0 || started) {
+        started = true;
+        const hex = digits[i].toString(16);
+        if (result.length > 0) {
+          result += hex.padStart(4, '0');
+        } else {
+          result += hex;
+        }
+      }
+    }
+    return result || '0';
+  }
+
+  /**
+   * BigInt 数组乘法
+   */
+  private static bigIntMultiply(a: number[], b: number[]): number[] {
+    const result: number[] = new Array(262).fill(0);
+    const aLen = NeteaseEncrypt.getHighIndex(a);
+    const bLen = NeteaseEncrypt.getHighIndex(b);
+
+    for (let i = 0; i <= bLen; i++) {
+      let carry = 0;
+      for (let j = 0; j <= aLen; j++) {
+        const product = result[i + j] + a[j] * b[i] + carry;
+        result[i + j] = product & 0xFFFF;
+        carry = product >>> 16;
+      }
+      result[i + aLen + 1] = carry;
+    }
+    return result;
+  }
+
+  /**
+   * 获取最高有效位索引
+   */
+  private static getHighIndex(digits: number[]): number {
+    for (let i = digits.length - 1; i >= 0; i--) {
+      if (digits[i] !== 0) return i;
+    }
+    return 0;
+  }
+
+  /**
+   * 获取 BigInt 数组的位数
+   */
+  private static getNumBits(digits: number[]): number {
+    const highIndex = NeteaseEncrypt.getHighIndex(digits);
+    let digit = digits[highIndex];
+    let bits = (highIndex + 1) * 16;
+    for (let i = 0; i < 16 && (digit & 0x8000) === 0; i++) {
+      bits--;
+      digit <<= 1;
+    }
+    return bits;
+  }
+
+  /**
+   * BigInt 数组左移
+   */
+  private static bigIntShiftLeft(a: number[], bits: number): number[] {
+    const digitShift = Math.floor(bits / 16);
+    const bitShift = bits % 16;
+    const result: number[] = new Array(a.length + digitShift + 1).fill(0);
+
+    for (let i = 0; i < a.length; i++) {
+      result[i + digitShift] |= (a[i] << bitShift) & 0xFFFF;
+      if (bitShift > 0 && i + digitShift + 1 < result.length) {
+        result[i + digitShift + 1] |= a[i] >>> (16 - bitShift);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * BigInt 数组右移
+   */
+  private static bigIntShiftRight(a: number[], bits: number): number[] {
+    const digitShift = Math.floor(bits / 16);
+    const bitShift = bits % 16;
+    const result: number[] = new Array(a.length).fill(0);
+
+    for (let i = digitShift; i < a.length; i++) {
+      result[i - digitShift] = (a[i] >>> bitShift) & 0xFFFF;
+      if (bitShift > 0 && i + 1 < a.length) {
+        result[i - digitShift] |= (a[i + 1] << (16 - bitShift)) & 0xFFFF;
+      }
+    }
+    return result;
+  }
+
+  /**
+   * BigInt 数组比较
+   */
+  private static bigIntCompare(a: number[], b: number[]): number {
+    const aHigh = NeteaseEncrypt.getHighIndex(a);
+    const bHigh = NeteaseEncrypt.getHighIndex(b);
+
+    if (aHigh !== bHigh) {
+      return aHigh > bHigh ? 1 : -1;
+    }
+
+    for (let i = aHigh; i >= 0; i--) {
+      if (a[i] !== b[i]) {
+        return a[i] > b[i] ? 1 : -1;
+      }
+    }
+    return 0;
+  }
+
+  /**
+   * BigInt 数组减法
+   */
+  private static bigIntSubtract(a: number[], b: number[]): number[] {
+    const result: number[] = new Array(Math.max(a.length, b.length)).fill(0);
+    let borrow = 0;
+
+    for (let i = 0; i < result.length; i++) {
+      const aVal = i < a.length ? a[i] : 0;
+      const bVal = i < b.length ? b[i] : 0;
+      let diff = aVal - bVal - borrow;
+
+      if (diff < 0) {
+        diff += 0x10000;
+        borrow = 1;
+      } else {
+        borrow = 0;
+      }
+      result[i] = diff;
+    }
+    return result;
+  }
+
+  /**
+   * BigInt 数组取模
+   */
+  private static bigIntMod(a: number[], m: number[]): number[] {
+    let result = a.slice();
+
+    while (NeteaseEncrypt.bigIntCompare(result, m) >= 0) {
+      const resultBits = NeteaseEncrypt.getNumBits(result);
+      const mBits = NeteaseEncrypt.getNumBits(m);
+      const shift = resultBits - mBits;
+
+      let shifted = NeteaseEncrypt.bigIntShiftLeft(m, shift);
+      if (NeteaseEncrypt.bigIntCompare(result, shifted) < 0) {
+        shifted = NeteaseEncrypt.bigIntShiftLeft(m, shift - 1);
+      }
+      result = NeteaseEncrypt.bigIntSubtract(result, shifted);
+    }
+    return result;
+  }
+
+  /**
+   * 模幂运算 (base^exp mod mod)
+   */
+  private static modPow(base: number[], exp: number[], mod: number[]): number[] {
+    let result: number[] = new Array(131).fill(0);
+    result[0] = 1;
+
+    let b = base.slice();
+    let e = exp.slice();
+
+    while (NeteaseEncrypt.getHighIndex(e) > 0 || e[0] !== 0) {
+      if ((e[0] & 1) === 1) {
+        result = NeteaseEncrypt.bigIntMod(NeteaseEncrypt.bigIntMultiply(result, b), mod);
+      }
+      e = NeteaseEncrypt.bigIntShiftRight(e, 1);
+      if (NeteaseEncrypt.getHighIndex(e) > 0 || e[0] !== 0) {
+        b = NeteaseEncrypt.bigIntMod(NeteaseEncrypt.bigIntMultiply(b, b), mod);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * RSA 加密（使用自定义大数运算）
+   * @param text 明文
+   * @returns 十六进制密文
+   */
+  private static rsaEncrypt(text: string): string {
+    // 将文本反转并转换为十六进制
+    const reversedText = NeteaseEncrypt.reverseString(text);
+    let hexText = '';
+    for (let i = 0; i < reversedText.length; i++) {
+      hexText += reversedText.charCodeAt(i).toString(16).padStart(2, '0');
+    }
+
+    // 转换为 BigInt 数组
+    const textBigInt = NeteaseEncrypt.hexToBigIntArray(hexText);
+    const expBigInt = NeteaseEncrypt.hexToBigIntArray(PUB_KEY);
+    const modBigInt = NeteaseEncrypt.hexToBigIntArray(MODULUS);
+
+    // 执行模幂运算
+    const result = NeteaseEncrypt.modPow(textBigInt, expBigInt, modBigInt);
+
+    // 转换为十六进制字符串，确保长度为 256
+    let hexResult = NeteaseEncrypt.bigIntArrayToHex(result);
+    while (hexResult.length < 256) {
+      hexResult = '0' + hexResult;
+    }
+    return hexResult;
+  }
+
+  /**
+   * 加密请求参数（主入口）
+   * @param data 要加密的数据对象
+   * @returns 加密后的参数
+   */
+  public static async encrypt(data: object): Promise<EncryptedParams> {
+    try {
+      const text = JSON.stringify(data);
+
+      // 生成 16 位随机密钥
+      const secretKey = NeteaseEncrypt.generateRandomString(16);
+
+      // 第一次 AES 加密：使用固定密钥 NONCE
+      const firstEncrypt = await NeteaseEncrypt.aesEncrypt(text, NONCE);
+
+      // 第二次 AES 加密：使用随机密钥
+      const params = await NeteaseEncrypt.aesEncrypt(firstEncrypt, secretKey);
+
+      // RSA 加密随机密钥
+      const encSecKey = NeteaseEncrypt.rsaEncrypt(secretKey);
+
+      return {
+        params: params,
+        encSecKey: encSecKey
+      };
+    } catch (error) {
+      console.error('[NeteaseEncrypt] Encrypt error:', error);
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw new Error(`Encrypt error: ${String(error)}`);
+    }
+  }
+
+  /**
+   * 同步版本的加密方法
+   * @param data 要加密的数据对象
+   * @returns 加密后的参数
+   */
+  public static encryptSync(data: object): EncryptedParams {
+    try {
+      const text = JSON.stringify(data);
+
+      // 生成 16 位随机密钥
+      const secretKey = NeteaseEncrypt.generateRandomString(16);
+
+      // 使用同步方式进行 AES 加密
+      const firstEncrypt = NeteaseEncrypt.aesEncryptSync(text, NONCE);
+      const params = NeteaseEncrypt.aesEncryptSync(firstEncrypt, secretKey);
+
+      // RSA 加密随机密钥
+      const encSecKey = NeteaseEncrypt.rsaEncrypt(secretKey);
+
+      return {
+        params: params,
+        encSecKey: encSecKey
+      };
+    } catch (error) {
+      console.error('[NeteaseEncrypt] EncryptSync error:', error);
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw new Error(`EncryptSync error: ${String(error)}`);
+    }
+  }
+
+  /**
+   * 同步 AES-128-CBC 加密
+   */
+  private static aesEncryptSync(text: string, key: string): string {
+    try {
+      const keyData = new Uint8Array(buffer.from(key, 'utf-8').buffer);
+      const ivData = new Uint8Array(buffer.from(IV, 'utf-8').buffer);
+      const plainData = new Uint8Array(buffer.from(text, 'utf-8').buffer);
+
+      const symKeyGenerator = cryptoFramework.createSymKeyGenerator('AES128');
+      const symKeyBlob: cryptoFramework.DataBlob = { data: keyData };
+      const symKey = symKeyGenerator.convertKeySync(symKeyBlob);
+
+      const ivParamsSpec: cryptoFramework.IvParamsSpec = {
+        algName: 'IvParamsSpec',
+        iv: { data: ivData }
+      };
+
+      const cipher = cryptoFramework.createCipher('AES128|CBC|PKCS7');
+      cipher.initSync(cryptoFramework.CryptoMode.ENCRYPT_MODE, symKey, ivParamsSpec);
+      const cipherData = cipher.doFinalSync({ data: plainData });
+
+      const base64Helper = new util.Base64Helper();
+      return base64Helper.encodeToStringSync(cipherData.data);
+    } catch (error) {
+      console.error('[NeteaseEncrypt] AES encryptSync error:', error);
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw new Error(`AES encryptSync error: ${String(error)}`);
+    }
+  }
+}


### PR DESCRIPTION
# PR: 实现网易云音乐歌词获取与系统媒体控制中心显示功能

## 概述

本 PR 实现了自动获取网易云音乐歌词并同步到 HarmonyOS AVSession 的功能，使系统媒体控制中心能够显示实时歌词。通过拦截网页请求获取歌曲 ID，再使用本地加密构造 API 请求获取歌词，最终将歌词同步到系统 AVSession。

## 主要改动

### 1. 新增歌词服务 (LyricService.ets)
- **单例模式设计**：确保全局唯一实例
- **歌词获取**：通过网易云音乐 weapi 接口获取 LRC 格式歌词
- **请求加密**：复用 NeteaseEncrypt 工具类对请求参数进行加密
- **Cookie 管理**：从 WebCookieManager 获取 Cookie 和 csrf_token
- **内容过滤**：过滤非标准 LRC 内容（如 JSON 格式的作词/作曲元数据），只保留标准时间标签格式
- **缓存机制**：避免重复请求相同歌曲的歌词

### 2. 修改 WebMusicBridge (WebMusicBridge.ets)
- **集成歌词服务**：在歌曲切换时自动获取歌词
- **歌词同步**：获取到歌词后自动更新到 AVSession 的 metadata.lyric 字段
- **修复多歌手名称提取**：支持获取完整的多歌手信息（如 "歌手A / 歌手B / 歌手C"）
- **网络请求拦截**：同时支持 XMLHttpRequest 和 Fetch API 拦截

### 3. 修改 AVSessionService (AVSessionService.ets)
- **新增 getSession() 方法**：允许外部直接访问 AVSession 实例以更新歌词

## 技术实现

### 歌词过滤逻辑
网易云音乐 API 返回的歌词可能包含非标准内容：
- JSON 格式的元数据（作词、作曲信息）
- 非时间标签格式的行

过滤规则：
1. 跳过以 `{` 开头的 JSON 行
2. 只保留符合 `[mm:ss.xx]` 或 `[mm:ss.xxx]` 格式的标准 LRC 行

```typescript
private filterLyric(rawLyric: string): string {
  const lines = rawLyric.split('\n');
  const filteredLines: string[] = [];
  const lrcTimePattern = /^\[(\d{2}):(\d{2})\.(\d{2,3})\]/;

  for (const line of lines) {
    const trimmedLine = line.trim();
    if (!trimmedLine) continue;
    if (trimmedLine.startsWith('{')) continue; // 跳过 JSON 行
    if (lrcTimePattern.test(trimmedLine)) { // 只保留 LRC 时间标签格式
      filteredLines.push(line);
    }
  }
  return filteredLines.join('\n');
}
```

## 数据流程图

```
┌─────────────────┐    拦截响应     ┌─────────────────┐
│   网页播放音乐   │ ─────────────► │  获取歌曲 ID    │
│  (XHR/Fetch)    │                │                 │
└─────────────────┘                └────────┬────────┘
                                            │
                                            ▼
┌─────────────────┐    加密请求     ┌─────────────────┐
│  LyricService   │ ◄───────────── │ NeteaseEncrypt  │
│   获取歌词       │                │  AES + RSA      │
└────────┬────────┘                └─────────────────┘
         │
         │ 过滤 + 缓存
         ▼
┌─────────────────┐   setAVMetadata  ┌─────────────────┐
│ WebMusicBridge  │ ───────────────► │   AVSession     │
│   更新歌词       │                  │  系统媒体控制    │
└─────────────────┘                  └─────────────────┘
```

## 文件变更

| 文件 | 变更类型 | 说明 |
|------|----------|------|
| `entry/src/main/ets/service/LyricService.ets` | 新增 | 歌词服务，负责获取、过滤和缓存歌词 |
| `entry/src/main/ets/service/WebMusicBridge.ets` | 修改 | 集成歌词服务、添加网络拦截和歌词同步、修复多歌手提取 |
| `entry/src/main/ets/service/AVSessionService.ets` | 修改 | 新增 getSession 方法 |
| `entry/src/main/ets/utils/NeteaseEncrypt.ets` | 新增 | 网易云音乐 API 加密工具 |

## 测试要点

1. 播放歌曲时能正确拦截到歌曲 ID
2. 歌词 API 请求能正确加密并获取响应
3. 非标准 LRC 内容被正确过滤
4. 歌词能正确显示在系统媒体控制中心
5. 歌词缓存机制正常工作
6. 多歌手信息能正确提取和显示
7. 支持通过 XHR 和 Fetch 两种网络请求方式拦截